### PR TITLE
Fix RRFilt numeric difference computation

### DIFF
--- a/RRLab/R/RRFilt.R
+++ b/RRLab/R/RRFilt.R
@@ -1,6 +1,8 @@
 #' RRFilt
 #'
-#' This function gives an indication how big the difference is in selected variable. When applying normally distributed features with no effect results in abs(x-mean(x))/sd(x), resulting near to 0. When applying normally distributed features with high effect the mean != median, thus abs(x-mean(x))/sd(x). This should result in higher than 0 number, higher the better difference in 
+#' This function indicates how big the difference is in a numeric vector.
+#' It returns `abs(mean(x) - median(x)) / sd(x)`, which is close to zero for
+#' symmetric distributions and larger when the mean and median diverge.
 #'
 #' @param x Numeric vector
 #'
@@ -9,8 +11,6 @@
 #' apply(iris[,-5],2,RRFilt)
 #' @export
 
-RRFilt = function(x){
-
-function(x){abs(sum((x-median(x)))/sd(x))}
- 
- }
+RRFilt = function(x) {
+  abs(mean(x) - median(x)) / sd(x)
+}

--- a/RRLab/man/RRFilt.Rd
+++ b/RRLab/man/RRFilt.Rd
@@ -13,7 +13,7 @@ RRFilt(x)
 An indication of 'difference' in the given vector. Higher is better diff.
 }
 \description{
-This function gives an indication how big the difference is in selected variable. When applying normally distributed features with no effect results in abs(x-mean(x))/sd(x), resulting near to 0. When applying normally distributed features with high effect the mean != median, thus abs(x-mean(x))/sd(x). This should result in higher than 0 number, higher the better difference in
+This function gives an indication how big the difference is in a numeric vector. It calculates `abs(mean(x) - median(x)) / sd(x)`, which is near zero for symmetric distributions and larger when the mean and median diverge.
 }
 \examples{
 apply(iris[,-5],2,RRFilt)


### PR DESCRIPTION
## Summary
- fix `RRFilt` to compute `abs(mean(x) - median(x)) / sd(x)`
- update documentation for the corrected formula

## Testing
- `Rscript -e "source('RRLab/R/RRFilt.R');print(RRFilt(1:10))"`
- `Rscript -e "library(datasets); source('RRLab/R/RRFilt.R'); print(apply(iris[,-5],2,RRFilt))"`
- `Rscript -e "source('RRLab/R/RRFilt.R'); stopifnot(abs(RRFilt(c(rep(0,9),10))-0.3162278) < 1e-5); cat('tests passed\n')"`


------
https://chatgpt.com/codex/tasks/task_e_683ffb9828f8832987ec18dce3cb3a55