### PR TITLE
Fix KDEA doc typo

### DIFF
--- a/docs/Functions/KDEA.md
+++ b/docs/Functions/KDEA.md
@@ -9,7 +9,7 @@ An example using the diamonds dataset, trying to estimate the best robust featur
 # from tibble to dataframe
 data_diamond = as.data.frame(diamonds)
 
-# Fond the fair and ideal rows
+# Find the fair and ideal rows
 data_diamond = data_diamond[data_diamond[,2]%in%c("Ideal","Fair"),]
 
 # remove ghost factors


### PR DESCRIPTION
## Summary
- correct a typo in `docs/Functions/KDEA.md`

## Testing
- `R CMD check RRLab` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ffd0d2298832984fc199790e6b17a