### PR TITLE
Fix angle difference logic and add tests

### DIFF
--- a/RRLab/DESCRIPTION
+++ b/RRLab/DESCRIPTION
@@ -10,3 +10,4 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 Imports: ggplot2, ggfortify
+Suggests: testthat

--- a/RRLab/R/RRFE.R
+++ b/RRLab/R/RRFE.R
@@ -404,10 +404,10 @@ s_KRepeats = 25, s_KmeansRepeat = 10, verbose = TRUE, ShowPlots = FALSE,s_GetLoa
 		Angle_Features = atan2(a$rotation[,Resulting_contrast[2]], a$rotation[,Resulting_contrast[1]])
 		Angle_Features_deg = (Angle_Features/pi)*180
 		
-		# Find the diff in angle @RRR FIXMENOWBITCHANDSTUFF MODULO INCORECCT
-		Angle_diff_0 = abs(Angle_Features_deg - Angle_groups_deg)%%90
+		# Compute angle difference modulo 90°
+                Angle_diff_0 = abs(((Angle_Features_deg - Angle_groups_deg + 90) %% 180) - 90)
 
-		Angle_diff_90 = abs(abs(Angle_Features_deg - Angle_groups_deg)-90)%%90
+                Angle_diff_90 = abs(((Angle_Features_deg - Angle_groups_deg) %% 180) - 90)
 		
 		# order angles to get least up top
 		Angle_ordered = Angle_diff_0[order(Angle_diff_0)]

--- a/RRLab/R/RRFE_svm.R
+++ b/RRLab/R/RRFE_svm.R
@@ -524,10 +524,10 @@ MCC = function(OBSPRED, lev=NULL, model=NULL, showCM = FALSE){
 		Angle_Features = atan2(a$rotation[,Resulting_contrast[2]], a$rotation[,Resulting_contrast[1]])
 		Angle_Features_deg = (Angle_Features/pi)*180
 		
-		# Find the diff in angle @RRR FIXMENOWBITCHANDSTUFF MODULO INCORECCT
-		Angle_diff_0 = abs(Angle_Features_deg - Angle_groups_deg)%%90
+		# Compute angle difference modulo 90°
+                Angle_diff_0 = abs(((Angle_Features_deg - Angle_groups_deg + 90) %% 180) - 90)
 
-		Angle_diff_90 = abs(abs(Angle_Features_deg - Angle_groups_deg)-90)%%90
+                Angle_diff_90 = abs(((Angle_Features_deg - Angle_groups_deg) %% 180) - 90)
 		
 		# order angles to get least up top
 		Angle_ordered = Angle_diff_0[order(Angle_diff_0)]

--- a/RRLab/tests/testthat.R
+++ b/RRLab/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(RRLab)
+
+test_check("RRLab")

--- a/RRLab/tests/testthat/test-RRFE.R
+++ b/RRLab/tests/testthat/test-RRFE.R
@@ -1,0 +1,20 @@
+context("RRFE")
+
+set.seed(123)
+
+results <- RRFE(dataset = iris,
+                f_dataset_class_column_id = which(colnames(iris)=="Species"),
+                s_MinimalVariance = 0.5,
+                s_MaxComponents = 2,
+                s_KRepeats = 2,
+                s_KmeansRepeat = 2,
+                verbose = FALSE,
+                ShowPlots = FALSE)
+
+# Expect a list with the BestFeatureNames element and at least one feature
+
+test_that("RRFE returns feature names", {
+  expect_true("BestFeatureNames" %in% names(results))
+  expect_type(results$BestFeatureNames, "character")
+  expect_gt(length(results$BestFeatureNames), 0)
+})


### PR DESCRIPTION
## Summary
- clarify angle difference computation and fix modulo logic in `RRFE` and `RRFE_svm`
- add testthat unit test for `RRFE`
- allow tests by suggesting `testthat` in DESCRIPTION

## Testing
- `R -q -e "devtools::test('RRLab')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400b11e5ac8329bc5043617f223784