### PR TITLE
Fix library usage in docs and KDEA examples

### DIFF
--- a/RRLab/R/KDEA.R
+++ b/RRLab/R/KDEA.R
@@ -56,7 +56,7 @@
 #' Example using transcriptiomic data
 #'
 #' Get data from mixOmics
-#' library(mixOmics)
+#' RRLab::libraryR(mixOmics)
 #' data(stemcells)
 #'
 #' KDEA(dataset = data.frame((stemcells$gene),Class = stemcells$celltype), f_dataset_class_column_id = stemcells$celltype,s_CovOfImportance = 1 , s_CovFormula = "~ Class")

--- a/RRLab/man/KDEA.Rd
+++ b/RRLab/man/KDEA.Rd
@@ -78,7 +78,7 @@ KDEA(dataset = mtcars, f_dataset_class_column_id = which(colnames(mtcars)=="am")
 Example using transcriptiomic data
 
 Get data from mixOmics
-library(mixOmics)
+RRLab::libraryR(mixOmics)
 data(stemcells)
 
 KDEA(dataset = data.frame((stemcells$gene),Class = stemcells$celltype), f_dataset_class_column_id = stemcells$celltype,s_CovOfImportance = 1 , s_CovFormula = "~ Class")

--- a/docs/Functions/PCACorrelations.md
+++ b/docs/Functions/PCACorrelations.md
@@ -55,7 +55,7 @@ Below is an example script that runs the entire workflow:
 
 ```R
 # Load necessary package
-library(ggplot2)
+RRLab::libraryR(ggplot2)
 
 # 1. Generate simulated data
 simulated_data <- generateRealisticBetaData(

--- a/docs/Functions/RRdistribution.md
+++ b/docs/Functions/RRdistribution.md
@@ -15,7 +15,7 @@ The function returns a list containing two elements:
 ## Examples
 ```R
 # Load the required package
-library(fitdistrplus)
+RRLab::libraryR(fitdistrplus)
 
 # Example 1: Using iris dataset
 data(iris)


### PR DESCRIPTION
## Summary
- use `RRLab::libraryR()` in docs
- update example in `KDEA` roxygen comments
- sync man page with new example

## Testing
- `R CMD build RRLab` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401296fd4c83298b43140455a7da72