### PR TITLE
Add file location fallback for Rload and Rsave

### DIFF
--- a/RRLab/R/Rload.R
+++ b/RRLab/R/Rload.R
@@ -4,12 +4,15 @@
 #' If `name` is an object, its name will be used to construct the
 #' file name using the supplied prefix and postfix. Alternatively a
 #' character string can be provided to directly specify the base file
-#' name. Files are loaded from `s_saveloc_qc` by default.
+#' name. If `file_location` is not provided, the function attempts to use
+#' `s_saveloc_qc` from the calling environment. If neither is available an
+#' error is thrown.
 #'
 #' @param name Object or character string identifying the file to load.
 #' @param prefix Optional prefix used during saving.
 #' @param postfix Optional postfix used during saving.
-#' @param file_location Directory of the saved file. Defaults to `s_saveloc_qc`.
+#' @param file_location Directory of the saved file. If `NULL`, `s_saveloc_qc`
+#'   is used when available.
 #' @param envir Environment to load the object into. Defaults to the caller's
 #'   environment.
 #' @param ... Additional arguments passed to `qs::qload`.
@@ -21,9 +24,17 @@
 #' Rload("08A_a_cohort")
 #' }
 #' @export
-Rload <- function(name, prefix = "", postfix = "", file_location = s_saveloc_qc,
+Rload <- function(name, prefix = "", postfix = "", file_location = NULL,
                   envir = parent.frame(), ...) {
   name_expr <- substitute(name)
+
+  if (is.null(file_location)) {
+    if (exists("s_saveloc_qc", inherits = TRUE)) {
+      file_location <- get("s_saveloc_qc", inherits = TRUE)
+    } else {
+      stop("file_location must be provided or 's_saveloc_qc' must exist")
+    }
+  }
 
   if (is.character(name)) {
     base <- name

--- a/RRLab/R/Rsave.R
+++ b/RRLab/R/Rsave.R
@@ -2,13 +2,14 @@
 #'
 #' Convenience wrapper around `qs::qsavem` that saves an object using its
 #' name in the calling environment. A prefix and postfix can be supplied to
-#' modify the file name and `s_saveloc_qc` is used as the default directory.
+#' modify the file name. If `file_location` is not supplied, `s_saveloc_qc`
+#' will be used when available.
 #'
 #' @param object Object to save or the name of the object.
 #' @param prefix Optional prefix for the file name.
 #' @param postfix Optional postfix for the file name.
-#' @param file_location Directory where the file will be saved. Defaults to
-#'   `s_saveloc_qc`.
+#' @param file_location Directory where the file will be saved. If `NULL`,
+#'   `s_saveloc_qc` will be used when available.
 #' @param ... Additional arguments passed to `qs::qsavem`.
 #'
 #' @return Invisibly returns the file path used.
@@ -19,9 +20,17 @@
 #' Rsave(a, prefix = "08A", postfix = "cohort")
 #' }
 #' @export
-Rsave <- function(object, prefix = "", postfix = "", file_location = s_saveloc_qc, ...) {
+Rsave <- function(object, prefix = "", postfix = "", file_location = NULL, ...) {
   obj_expr <- substitute(object)
   obj_name <- deparse(obj_expr)
+
+  if (is.null(file_location)) {
+    if (exists("s_saveloc_qc", inherits = TRUE)) {
+      file_location <- get("s_saveloc_qc", inherits = TRUE)
+    } else {
+      stop("file_location must be provided or 's_saveloc_qc' must exist")
+    }
+  }
 
   # If a character string is provided, treat it as a variable name
   if (is.character(object) && length(object) == 1 && !exists(obj_name, envir = parent.frame())) {

--- a/RRLab/man/Rload.Rd
+++ b/RRLab/man/Rload.Rd
@@ -4,13 +4,13 @@
 \alias{Rload}
 \title{Rload}
 \usage{
-Rload(name, prefix = "", postfix = "", file_location = s_saveloc_qc, envir = parent.frame(), ...)
+Rload(name, prefix = "", postfix = "", file_location = NULL, envir = parent.frame(), ...)
 }
 \arguments{
 \item{name}{Object or file name to load.}
 \item{prefix}{Optional prefix used during saving.}
 \item{postfix}{Optional postfix used during saving.}
-\item{file_location}{Directory of the saved file. Defaults to \code{s_saveloc_qc}.}
+\item{file_location}{Directory of the saved file. If \code{NULL}, \code{s_saveloc_qc} will be used when available.}
 \item{envir}{Environment to load the object into. Defaults to the caller's environment.}
 \item{...}{Additional arguments passed to \code{qs::qload}.}
 }

--- a/RRLab/man/Rsave.Rd
+++ b/RRLab/man/Rsave.Rd
@@ -4,20 +4,20 @@
 \alias{Rsave}
 \title{Rsave}
 \usage{
-Rsave(object, prefix = "", postfix = "", file_location = s_saveloc_qc, ...)
+Rsave(object, prefix = "", postfix = "", file_location = NULL, ...)
 }
 \arguments{
 \item{object}{Object to save or the name of the object.}
 \item{prefix}{Optional prefix for the file name.}
 \item{postfix}{Optional postfix for the file name.}
-\item{file_location}{Directory where the file will be saved. Defaults to \code{s_saveloc_qc}.}
+\item{file_location}{Directory where the file will be saved. If \code{NULL}, \code{s_saveloc_qc} will be used when available.}
 \item{...}{Additional arguments passed to \code{qs::qsavem}.}
 }
 \value{
 Invisibly returns the path used to save the object.
 }
 \description{
-Convenience wrapper around \code{qs::qsavem} that saves an object by its R name. You can specify a prefix, postfix and file location. The default directory is \code{s_saveloc_qc}.
+Convenience wrapper around \code{qs::qsavem} that saves an object by its R name. You can specify a prefix, postfix and file location. If \code{file_location} is omitted, \code{s_saveloc_qc} will be used when available.
 }
 \examples{
 a <- 1:5

--- a/docs/Functions/Rload.md
+++ b/docs/Functions/Rload.md
@@ -2,18 +2,18 @@
 
 # Rload Function
 
-`Rload()` compliments `Rsave()` by loading a previously saved object with `qs::qload`. Provide an object or file name base and it rebuilds the path using the same prefix/postfix logic.
+`Rload()` compliments `Rsave()` by loading a previously saved object with `qs::qload`. Provide an object or file name base and it rebuilds the path using the same prefix/postfix logic. When `file_location` is `NULL`, `s_saveloc_qc` is used if available.
 
 ## Usage
 ```R
-Rload(name, prefix = "", postfix = "", file_location = s_saveloc_qc, envir = parent.frame(), ...)
+Rload(name, prefix = "", postfix = "", file_location = NULL, envir = parent.frame(), ...)
 ```
 
 ## Parameters
 - `name`: The object or file name to load.
 - `prefix`: Optional prefix that was used when saving.
 - `postfix`: Optional postfix used when saving.
-- `file_location`: Directory of the saved object, defaults to `s_saveloc_qc`.
+- `file_location`: Directory of the saved object. If `NULL`, `s_saveloc_qc` is used when available.
 - `envir`: Environment to load the object into. Default is the caller's environment.
 
 ## Returns

--- a/docs/Functions/Rsave.md
+++ b/docs/Functions/Rsave.md
@@ -2,18 +2,18 @@
 
 # Rsave Function
 
-`Rsave()` is a lightweight wrapper around `qs::qsavem` to store an object using its name. It automatically appends optional prefixes or postfixes and defaults to saving in `s_saveloc_qc`.
+`Rsave()` is a lightweight wrapper around `qs::qsavem` to store an object using its name. It automatically appends optional prefixes or postfixes. When `file_location` is `NULL`, `s_saveloc_qc` will be used if available.
 
 ## Usage
 ```R
-Rsave(object, prefix = "", postfix = "", file_location = s_saveloc_qc, ...)
+Rsave(object, prefix = "", postfix = "", file_location = NULL, ...)
 ```
 
 ## Parameters
 - `object`: Object to save or the name of the object.
 - `prefix`: Optional prefix added to the file name.
 - `postfix`: Optional postfix added to the file name.
-- `file_location`: Directory where the file will be stored. Defaults to `s_saveloc_qc`.
+- `file_location`: Directory where the file will be stored. If `NULL`, `s_saveloc_qc` will be used when available.
 
 ## Returns
 The full file path invisibly, after the object is saved with `qs::qsavem`.


### PR DESCRIPTION
## Summary
- update `Rload()` and `Rsave()` so `file_location` defaults to `s_saveloc_qc` when available
- update documentation and manuals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68401a760bb08329999603fc9f2f463c