### PR TITLE
Check for RRLab updates on package attach

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # RRLab Release Notes
 
+## 0.0.0.1001
+- Check for newer RRLab versions on package attach.
+
 ## 0.0.0.1000
 - Initial public release of RRLab.
 - Includes feature extraction tools (RRFE), cross-validation DEA (KDEA), data scanning utilities, and more.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ To install the RRLab package
 ```
 devtools::install_github("Rrtk2/RRLab/RRLab")
 ```
+Once loaded with `library(RRLab)`, the package automatically checks GitHub for
+new releases and notifies you if an update is available.
 ---
 
 ## Contributing

--- a/RRLab/DESCRIPTION
+++ b/RRLab/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RRLab
 Type: Package
 Title: Rick Reijnders's Miscellaneous Functions
-Version: 0.0.0.1000
+Version: 0.0.0.1001
 Authors@R: person("Rick", "Reijnders", email = "Rick.Reijnders@home.nl", role = c("aut", "cre"))
 Description: Contains many functions useful for data analysis, high-level graphics, utility operations, and other functions.
 License: GPL (>= 3)

--- a/RRLab/R/zzz.R
+++ b/RRLab/R/zzz.R
@@ -1,3 +1,26 @@
+
+check_rrlab_update <- function() {
+  remote_version <- tryCatch({
+    con <- url("https://raw.githubusercontent.com/Rrtk2/RRLab/master/RRLab/DESCRIPTION")
+    on.exit(close(con), add = TRUE)
+    desc_text <- readLines(con, warn = FALSE)
+    desc <- read.dcf(textConnection(desc_text))
+    desc[1, "Version"]
+  }, error = function(e) NA_character_)
+
+  local_version <- utils::packageDescription("RRLab")$Version
+
+  if (!is.na(remote_version) &&
+      utils::compareVersion(as.character(remote_version), as.character(local_version)) > 0) {
+    packageStartupMessage(
+      sprintf(
+        "A newer version of RRLab (%s) is available. Run devtools::install_github('Rrtk2/RRLab/RRLab') to update.",
+        remote_version
+      )
+    )
+  }
+}
+
 .onAttach <- function(libname, pkgname) {
 
 	if (!isTRUE(getOption("RRLab.suppressStartup", FALSE))) {
@@ -32,6 +55,8 @@
                         "data.table", "splitstackshape")
 
   RRLab::libraryR(c(s_requiredpackages))
+
+  check_rrlab_update()
 
 
 }


### PR DESCRIPTION
## Summary
- add `check_rrlab_update()` to retrieve latest version from GitHub
- run update check when the package attaches
- bump package version to 0.0.0.1001
- mention update behaviour in README
- document change in `NEWS.md`

## Testing
- `R CMD build RRLab` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68401e54e7e48329b8e27cde0d4bfe4b