### PR TITLE
Fix libraryR evaluation environment

### DIFF
--- a/RRLab/R/libraryR.R
+++ b/RRLab/R/libraryR.R
@@ -29,7 +29,7 @@ libraryR = function(pkg) {
   }
   
   pkg = substitute(pkg)
-  pkg = if (is.name(pkg)) as.character(pkg) else eval(pkg)
+  pkg = if (is.name(pkg)) as.character(pkg) else eval(pkg, parent.frame())
   
   results = setNames(logical(length(pkg)), pkg)
   


### PR DESCRIPTION
## Summary
- update `libraryR` so it evaluates expressions in the parent frame

## Testing
- `R CMD build RRLab`
- `R CMD check RRLab_0.0.0.1000.tar.gz` *(fails: packages required but not available)*

------
https://chatgpt.com/codex/tasks/task_e_684022e5af0c8329b0f30767dd2148f8