### PR TITLE
Add testthat support

### DIFF
--- a/RRLab/DESCRIPTION
+++ b/RRLab/DESCRIPTION
@@ -12,3 +12,4 @@ RoxygenNote: 7.3.2
 Imports: ggplot2, ggfortify, matlib, fitdistrplus, caret, limma,
         tidyverse, ggsci, showtext, foreach, doParallel, parallel,
         progress, data.table, splitstackshape, jsonlite
+Suggests: testthat

--- a/RRLab/tests/testthat.R
+++ b/RRLab/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(RRLab)
+
+test_check("RRLab")

--- a/RRLab/tests/testthat/test-RRnorm.R
+++ b/RRLab/tests/testthat/test-RRnorm.R
@@ -1,0 +1,10 @@
+test_that("RRnorm scales values between 0 and 1 by default", {
+  x <- c(1, 2, 3, 4, 5)
+  expect_equal(RRnorm(x), (x - min(x)) / (max(x) - min(x)))
+})
+
+test_that("RRnorm applies Scalar and Offset correctly", {
+  x <- c(1, 2, 3, 4, 5)
+  expect_equal(RRnorm(x, Scalar = 2, Offset = -1),
+               ((x - min(x)) / (max(x) - min(x))) * 2 - 1)
+})

--- a/RRLab/tests/testthat/test-median2.R
+++ b/RRLab/tests/testthat/test-median2.R
@@ -1,0 +1,9 @@
+test_that("median2 returns median for numeric vector", {
+  x <- c(1, 3, 2, 5, 4)
+  expect_equal(median2(x), 3)
+})
+
+test_that("median2 returns correct level for factor vector", {
+  x <- factor(c("low", "medium", "high"), levels = c("low", "medium", "high"))
+  expect_equal(median2(x), "medium")
+})


### PR DESCRIPTION
## Summary
- add testthat dependency
- add baseline tests for `median2` and `RRnorm`

## Testing
- `Rscript -e "library(testthat); source('RRLab/R/median.R'); source('RRLab/R/RRnorm.R'); test_dir('RRLab/tests/testthat')"`


------
https://chatgpt.com/codex/tasks/task_e_6841aca119008329a17a18dfc9224b87