### PR TITLE
Document parallelOuterToBigMat

### DIFF
--- a/RRLab/R/parallelOuterToBigMat.R
+++ b/RRLab/R/parallelOuterToBigMat.R
@@ -6,6 +6,10 @@
 #' `RcppParallel`, allowing large interaction matrices to be generated
 #' without exhausting RAM.
 #'
+#' This function requires the `bigmemory` and `RcppParallel` packages.
+#' The outer product is computed in parallel and streamed directly to
+#' the file-backed matrix so vectors larger than memory can be processed.
+#'
 #' @param x Numeric vector. Typically a flattened matrix.
 #' @param bigmat A `bigmemory::big.matrix` object used to store the
 #'   interaction matrix on disk.
@@ -24,6 +28,7 @@
 #' )
 #' parallelOuterToBigMat(x, bm)
 #' bm[, ]
+#' all.equal(bm[, ], outer(x, x))
 #' @export
 parallelOuterToBigMat <- function(x, bigmat) {
   if (!inherits(bigmat, "big.matrix")) {

--- a/docs/Functions/FunctionsOverview.md
+++ b/docs/Functions/FunctionsOverview.md
@@ -62,3 +62,4 @@
 [Rload](https://github.com/Rrtk2/RRLab/blob/master/docs/Functions/Rload.md)
 
 [Rsave](https://github.com/Rrtk2/RRLab/blob/master/docs/Functions/Rsave.md)
+[parallelOuterToBigMat](https://github.com/Rrtk2/RRLab/blob/master/docs/Functions/parallelOuterToBigMat.md)

--- a/docs/Functions/parallelOuterToBigMat.md
+++ b/docs/Functions/parallelOuterToBigMat.md
@@ -1,0 +1,36 @@
+| [HOME](https://github.com/Rrtk2/RRLab)  |  [FUNCTIONS](https://github.com/Rrtk2/RRLab/blob/master/docs/Functions/FunctionsOverview.md)  |
+
+# parallelOuterToBigMat function
+
+## Description
+`parallelOuterToBigMat()` computes the outer product of a numeric vector in parallel and writes the result directly to a file-backed `big.matrix`. This avoids allocating the full matrix in memory and allows the creation of very large interaction matrices. The function relies on the **bigmemory** and **RcppParallel** packages.
+
+## Usage
+```R
+parallelOuterToBigMat(x, bigmat)
+```
+
+## Parameters
+- `x`: Numeric vector with values to multiply.
+- `bigmat`: A `bigmemory::big.matrix` used as the output container.
+
+## Return Value
+Invisibly returns `bigmat` after it has been filled with the outer product of `x`.
+
+## Examples
+```R
+library(bigmemory)
+x <- rnorm(4)
+bf <- tempfile(fileext = ".bin")
+df <- tempfile(fileext = ".desc")
+bm <- bigmemory::filebacked.big.matrix(
+  nrow = length(x),
+  ncol = length(x),
+  type = "double",
+  backingfile = basename(bf),
+  descriptorfile = basename(df),
+  backingpath = dirname(bf)
+)
+parallelOuterToBigMat(x, bm)
+print(bm[, ])
+```


### PR DESCRIPTION
## Summary
- clarify `parallelOuterToBigMat` roxygen docs
- add example output verification
- add new function documentation file
- link `parallelOuterToBigMat` in FunctionsOverview

## Testing
- `Rscript -e "print('hello')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492b50a4a08329a770b79dc797258c